### PR TITLE
Add missing realtime controls

### DIFF
--- a/rvc-rs/ui/src-tauri/src/lib.rs
+++ b/rvc-rs/ui/src-tauri/src/lib.rs
@@ -1,6 +1,18 @@
+use log::info;
+
+/// Print events coming from the front-end.
+#[tauri::command]
+fn frontend_event(event: String, value: Option<String>) {
+  match value {
+    Some(v) => info!("frontend event: {} = {}", event, v),
+    None => info!("frontend event: {}", event),
+  }
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
   tauri::Builder::default()
+    .invoke_handler(tauri::generate_handler![frontend_event])
     .setup(|app| {
       if cfg!(debug_assertions) {
         app.handle().plugin(

--- a/rvc-rs/ui/src/App.vue
+++ b/rvc-rs/ui/src/App.vue
@@ -72,6 +72,7 @@
                         />
                         使用设备采样率</label
                     >
+                    <span class="info">采样率: {{ sampleRate }}</span>
                 </div>
             </section>
         </div>
@@ -106,6 +107,34 @@
                         v-model.number="formant"
                     />
                 </div>
+                <div class="slider">
+                    <label>Index Rate {{ indexRate }}</label>
+                    <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        v-model.number="indexRate"
+                    />
+                </div>
+                <div class="slider">
+                    <label>响度因子 {{ rmsMixRate }}</label>
+                    <input
+                        type="range"
+                        min="0"
+                        max="1"
+                        step="0.01"
+                        v-model.number="rmsMixRate"
+                    />
+                </div>
+                <div>
+                    <label>音高算法:</label>
+                    <label><input type="radio" value="pm" v-model="f0method" />pm</label>
+                    <label><input type="radio" value="harvest" v-model="f0method" />harvest</label>
+                    <label><input type="radio" value="crepe" v-model="f0method" />crepe</label>
+                    <label><input type="radio" value="rmvpe" v-model="f0method" />rmvpe</label>
+                    <label><input type="radio" value="fcpe" v-model="f0method" />fcpe</label>
+                </div>
             </section>
 
             <section>
@@ -130,11 +159,40 @@
                         v-model.number="crossfadeLength"
                     />
                 </div>
+                <div class="slider">
+                    <label>harvest进程数 {{ nCpu }}</label>
+                    <input
+                        type="range"
+                        min="1"
+                        max="8"
+                        step="1"
+                        v-model.number="nCpu"
+                    />
+                </div>
+                <div class="slider">
+                    <label>额外推理时长 {{ extraTime }}</label>
+                    <input
+                        type="range"
+                        min="0.05"
+                        max="5"
+                        step="0.01"
+                        v-model.number="extraTime"
+                    />
+                </div>
+                <div>
+                    <label><input type="checkbox" v-model="iNoiseReduce" /> 输入降噪</label>
+                    <label><input type="checkbox" v-model="oNoiseReduce" /> 输出降噪</label>
+                    <label><input type="checkbox" v-model="usePv" /> 启用相位声码器</label>
+                </div>
             </section>
         </div>
         <div class="actions">
             <button type="button" @click="startVc">开始音频转换</button>
             <button type="button" @click="stopVc">停止音频转换</button>
+            <label><input type="radio" value="im" v-model="functionMode" /> 输入监听</label>
+            <label><input type="radio" value="vc" v-model="functionMode" /> 输出变声</label>
+            <span class="info">算法延迟: {{ delayTime }} ms</span>
+            <span class="info">推理时间: {{ inferTime }} ms</span>
         </div>
     </div>
 </template>
@@ -158,9 +216,21 @@ const srType = ref("sr_model");
 const threshold = ref(-60);
 const pitch = ref(0);
 const formant = ref(0.0);
+const indexRate = ref(0.0);
+const rmsMixRate = ref(0.0);
+const f0method = ref("fcpe");
 
 const blockTime = ref(0.25);
 const crossfadeLength = ref(0.05);
+const nCpu = ref(1);
+const extraTime = ref(2.5);
+const iNoiseReduce = ref(false);
+const oNoiseReduce = ref(false);
+const usePv = ref(false);
+const functionMode = ref("vc");
+const sampleRate = ref(0);
+const delayTime = ref(0);
+const inferTime = ref(0);
 
 function send(event, value) {
     invoke("frontend_event", { event, value: value?.toString() });
@@ -171,6 +241,16 @@ watch(pitch, (v) => send("pitch", v));
 watch(formant, (v) => send("formant", v));
 watch(blockTime, (v) => send("block_time", v));
 watch(crossfadeLength, (v) => send("crossfade_length", v));
+watch(srType, (v) => send("sr_type", v));
+watch(indexRate, (v) => send("index_rate", v));
+watch(rmsMixRate, (v) => send("rms_mix_rate", v));
+watch(f0method, (v) => send("f0method", v));
+watch(nCpu, (v) => send("n_cpu", v));
+watch(extraTime, (v) => send("extra_time", v));
+watch(iNoiseReduce, (v) => send("I_noise_reduce", v));
+watch(oNoiseReduce, (v) => send("O_noise_reduce", v));
+watch(usePv, (v) => send("use_pv", v));
+watch(functionMode, (v) => send("function_mode", v));
 
 function reloadDevices() {
     send("reload_devices");
@@ -209,5 +289,8 @@ section {
     display: flex;
     gap: 1rem;
     margin-top: 1rem;
+}
+.info {
+    margin-left: 1rem;
 }
 </style>


### PR DESCRIPTION
## Summary
- add sliders and toggles for more realtime controls in the Vue UI
- expose algorithm delay/inference time readouts
- forward frontend events to Tauri and print them

## Testing
- `cargo check -p rvc-lib --manifest-path rvc-rs/Cargo.toml`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685153378fb88325bda61f1086afe664